### PR TITLE
Don't Show Players For Every Item

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 .PHONY: start
 start:
-	CLIENT_ID=TEST CLIENT_SECRET=TEST HOST=TEST go run main.go
+	CLIENT_ID=TEST CLIENT_SECRET=TEST HOST=TEST go run main.go handlers.go

--- a/handlers.go
+++ b/handlers.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	spotify "github.com/mike-webster/spotify-views/spotify"
+)
+
+func handlerOauth(c *gin.Context) {
+	ctx := context.WithValue(c, "return_url", returnURL)
+	ctx = context.WithValue(ctx, "client_id", clientID)
+	ctx = context.WithValue(ctx, "client_secret", clientSecret)
+	code := c.Query("code")
+	//state := c.Query("state")
+	qErr := c.Query("error")
+	if len(qErr) > 0 {
+		// the user is a fucker and they denied access
+	}
+	ctx, err := spotify.HandleOauth(ctx, code)
+	if err != nil {
+		c.JSON(500, gin.H{"err": err})
+		return
+	}
+	token := ctx.Value("access_token")
+	if token == nil {
+		c.JSON(500, gin.H{"err": "no access token"})
+		return
+	}
+	c.SetCookie("svauth", fmt.Sprint(token), 3600, "/", strings.Replace(host, "https://", "", -1), false, true)
+	c.Redirect(http.StatusTemporaryRedirect, "/tracks/top")
+}
+
+func handlerTopTracks(c *gin.Context) {
+	token, err := c.Cookie("svauth")
+	if err != nil {
+		log.Println("no token - redirecting to login")
+		c.Redirect(http.StatusTemporaryRedirect, "/login")
+		return
+	}
+	ctx := context.WithValue(c, "access_token", token)
+
+	tr := c.Query("time_range")
+	if len(tr) > 0 {
+		ctx = context.WithValue(ctx, "time_range", tr)
+	}
+
+	tracks, err := spotify.GetTopTracks(ctx, 25)
+	if err != nil {
+		c.JSON(500, gin.H{"err": err})
+		return
+	}
+
+	type tempBag struct {
+		Width    int32
+		Height   int32
+		ID       string
+		Name     string
+		Resource string
+	}
+	data := []tempBag{}
+	for _, i := range *tracks {
+		data = append(data, tempBag{
+			ID:       i.ID,
+			Height:   80,
+			Width:    300,
+			Resource: "track",
+			Name:     i.Name,
+		})
+	}
+
+	c.HTML(200, "toptracks.tmpl", data)
+}
+
+func handlerTopArtists(c *gin.Context) {
+	log.Println("getting token")
+	token, err := c.Cookie("svauth")
+	if err != nil {
+		log.Println("no token - redirecting to login")
+		c.Redirect(http.StatusTemporaryRedirect, "/login")
+		return
+	}
+	ctx := context.WithValue(c, "access_token", token)
+
+	tr := c.Query("time_range")
+	if len(tr) > 0 {
+		ctx = context.WithValue(ctx, "time_range", tr)
+	}
+	log.Println("getting artists")
+	artists, err := spotify.GetTopArtists(ctx)
+	if err != nil {
+		c.JSON(500, gin.H{"err": err})
+		return
+	}
+	type tempBag struct {
+		Width    int32
+		Height   int32
+		ID       string
+		Name     string
+		Resource string
+	}
+	data := []tempBag{}
+	for _, i := range *artists {
+		data = append(data, tempBag{
+			ID:       i.ID,
+			Height:   380,
+			Width:    300,
+			Resource: "artist",
+			Name:     i.Name,
+		})
+	}
+	c.HTML(200, "topartists.tmpl", data)
+}
+
+func handlerTopArtistsGenres(c *gin.Context) {
+	log.Println("getting token")
+	token, err := c.Cookie("svauth")
+	if err != nil {
+		log.Println("no token - redirecting to login")
+		c.Redirect(http.StatusTemporaryRedirect, "/login")
+		return
+	}
+	ctx := context.WithValue(c, "access_token", token)
+
+	tr := c.Query("time_range")
+	if len(tr) > 0 {
+		ctx = context.WithValue(ctx, "time_range", tr)
+	}
+	log.Println("getting artists")
+	artists, err := spotify.GetTopArtists(ctx)
+	if err != nil {
+		log.Println(err.Error())
+		c.JSON(500, gin.H{"err": err})
+		return
+	}
+	log.Println("getting genres")
+	genres, err := spotify.GetGenresForArtists(ctx, artists.IDs())
+	if err != nil {
+		c.JSON(500, gin.H{"err": err.Error()})
+		return
+	}
+	sort.Sort(sort.Reverse(genres))
+	log.Println(genres)
+	vb := ViewBag{Resource: "artist", Results: genres}
+	c.HTML(200, "topgenres.tmpl", vb)
+}
+
+func handlerTopTracksGenres(c *gin.Context) {
+	log.Println("getting token")
+	token, err := c.Cookie("svauth")
+	if err != nil {
+		log.Println("no token - redirecting to login")
+		c.Redirect(http.StatusTemporaryRedirect, "/login")
+		return
+	}
+	ctx := context.WithValue(c, "access_token", token)
+
+	tr := c.Query("time_range")
+	if len(tr) > 0 {
+		ctx = context.WithValue(ctx, "time_range", tr)
+	}
+	log.Println("getting top tracks")
+	tracks, err := spotify.GetTopTracks(ctx, 50)
+	if err != nil {
+		log.Println(err)
+		c.JSON(500, gin.H{"err": err.Error()})
+		return
+	}
+	log.Println("getting genres")
+	genres, err := spotify.GetGenresForTracks(ctx, tracks.IDs())
+	if err != nil {
+		c.JSON(500, gin.H{"err": err.Error()})
+		return
+	}
+	sort.Sort(sort.Reverse(genres))
+	log.Println(genres)
+	vb := ViewBag{Resource: "track", Results: genres}
+	c.HTML(200, "topgenres.tmpl", vb)
+}
+
+func handlerLogin(c *gin.Context) {
+	// TODO Add state
+	pathScopes := url.QueryEscape(strings.Join(scopes, " "))
+	redirectURL := fmt.Sprintf("https://accounts.spotify.com/authorize?response_type=code&client_id=%s&scope=%s&redirect_uri=%s&show_dialog=false",
+		clientID,
+		pathScopes,
+		returnURL)
+	c.Redirect(http.StatusTemporaryRedirect, redirectURL)
+}
+
+func handlerHome(c *gin.Context) {
+	c.HTML(200, "home.tmpl", nil)
+}

--- a/static/main.css
+++ b/static/main.css
@@ -13,3 +13,11 @@ a {
     font-family: inherit;
     color: white;
 }
+
+p { 
+    cursor: pointer;
+}
+
+a:hover {
+    background: darkgray;
+}

--- a/static/player.js
+++ b/static/player.js
@@ -1,0 +1,21 @@
+document.addEventListener("DOMContentLoaded", function(){
+    // when page is ready
+
+    var artists = document.getElementsByTagName("p");
+    for (let i = 0; i < artists.length; i++) {
+        var player = document.getElementById("i"+artists[i].getAttribute('id').substr(1))
+        players = document.getElementsByTagName("iframe");
+        artists[i].addEventListener("click", function() {
+            // hide all
+            for (let i = 0; i < players.length; i++) {
+                players[i].setAttribute("style", "display:none");
+            }
+
+            // show me
+            document.getElementById("i"+this.getAttribute('id').substr(1)).setAttribute("style", "");
+        });
+    }
+
+    // show first one
+    document.getElementsByTagName("iframe")[0].click();
+});

--- a/static/player.js
+++ b/static/player.js
@@ -1,6 +1,9 @@
 document.addEventListener("DOMContentLoaded", function(){
     // when page is ready
 
+    // TODO there is a bug in here somewhere.  the `substr` method is being called on nil
+    // it doesn't seem to be breaking anything so it's just noise in the console I'm ignoring.
+
     var artists = document.getElementsByTagName("p");
     for (let i = 0; i < artists.length; i++) {
         var player = document.getElementById("i"+artists[i].getAttribute('id').substr(1))

--- a/templates/player.tmpl
+++ b/templates/player.tmpl
@@ -1,0 +1,7 @@
+{{ define "player" }}
+    <div width="300" width="{{ .Width }}" style="text-algin:center">
+        <p id="h{{ .ID }}"> {{ .Name }} </p>
+        <iframe id="i{{.ID}}" style="display:none;" src="https://open.spotify.com/embed/{{ .Resource }}/{{ .ID }}" width="{{.Width}}" height="{{ .Height }}" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>
+    </div>
+{{ end }}
+

--- a/templates/topartists.tmpl
+++ b/templates/topartists.tmpl
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
     {{ template "header" }}
-
+    <script src="/static/js/player.js"></script>
     <body>
         {{ template "topnav" }}
         
@@ -12,7 +12,7 @@
             <a style="width:33%" href="/artists/top?time_range=short_term">Short Term</a><br /><br />
             {{ range . }}
                 <div style="width:100%">
-                    {{ . }}
+                    {{ template "player" . }}
                 </div>
             {{ end }}
         </div>

--- a/templates/toptracks.tmpl
+++ b/templates/toptracks.tmpl
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
     {{ template "header" }}
+    <script src="/static/js/player.js"></script>
 
     <body>
         {{ template "topnav" }}
@@ -12,7 +13,7 @@
             <a style="width:33%" href="/tracks/top?time_range=short_term">Short Term</a><br /><br />
             {{ range . }}
                 <div style="width:100%">
-                    {{ . }}
+                    {{ template "player" . }}
                 </div>
             {{ end }}
         </div>


### PR DESCRIPTION
## Description
When the top artist/track pages were loading, I was defaulting to show every player for every result that was loaded.  Now when the pages load, it looks like a list with only one player showing and you can load others by selecting other items in the list.