### PR TITLE
Bug Fix - Word cloud crash

### DIFF
--- a/templates/wordcloud.tmpl
+++ b/templates/wordcloud.tmpl
@@ -49,8 +49,9 @@
         .row.header, .row.footer {
             background-color: #1DB954;
             margin: 0;
-            padding: 5px 0px;
+            padding: 3px 0px;
             color: #FFF;
+            min-height: 25px;
         }
 
         .flex-table .col:nth-child(odd) {


### PR DESCRIPTION
## Description
If we were attempting to generate the word cloud and one of the user's top tracks doesn't have lyrics we can find we were causing a 500.  This change will log the errors when we receive 404s instead of returning the 404, which should in turn allow the application to generate the word cloud with the remaining songs it can find.